### PR TITLE
fix: su inaccessible or not found when using mode 1

### DIFF
--- a/post-fs-data.sh
+++ b/post-fs-data.sh
@@ -15,6 +15,26 @@ force_hide_lsposed=0
 
 echo "susfs4ksu/post-fs-data: [logging_initialized]" > $logfile1
 
+#### Enable sus_su ####
+enable_sus_su_mode_1(){
+  ## Here we manually create an system overlay an copy the sus_su and sus_su_drv_path to ${MODDIR}/system/bin after sus_su is enabled,
+  ## as ksu overlay script is executed after all post-fs-data.sh scripts are finished
+
+  rm -rf ${MODDIR}/system 2>/dev/null
+  # Enable sus_su or abort the function if sus_su is not supported #
+  if ! ${SUSFS_BIN} sus_su 1; then
+    return
+  fi
+  mkdir -p ${MODDIR}/system/bin 2>/dev/null
+  # Copy the new generated sus_su_drv_path and 'sus_su' to /system/bin/ and rename 'sus_su' to 'su' #
+  cp -f /data/adb/ksu/bin/sus_su ${MODDIR}/system/bin/su
+  cp -f /data/adb/ksu/bin/sus_su_drv_path ${MODDIR}/system/bin/sus_su_drv_path
+  echo 1 > ${MODDIR}/sus_su_mode
+  return
+}
+# uncomment it below to enable sus_su with mode 1 #
+#enable_sus_su_mode_1
+
 # to add paths
 # echo "/system/addon.d" >> /data/adb/susfs4ksu/sus_path.txt
 # this'll make it easier for the webui to do stuff

--- a/service.sh
+++ b/service.sh
@@ -12,26 +12,6 @@ hide_vendor_sepolicy=0
 hide_compat_matrix=0
 [ -f $PERSISTENT_DIR/config.sh ] && source $PERSISTENT_DIR/config.sh
 
-#### Enable sus_su ####
-enable_sus_su_mode_1(){
-  ## Here we manually create an system overlay an copy the sus_su and sus_su_drv_path to ${MODDIR}/system/bin after sus_su is enabled,
-  ## as ksu overlay script is executed after all post-fs-data.sh scripts are finished
-
-  rm -rf ${MODDIR}/system 2>/dev/null
-  # Enable sus_su or abort the function if sus_su is not supported #
-  if ! ${SUSFS_BIN} sus_su 1; then
-    return
-  fi
-  mkdir -p ${MODDIR}/system/bin 2>/dev/null
-  # Copy the new generated sus_su_drv_path and 'sus_su' to /system/bin/ and rename 'sus_su' to 'su' #
-  cp -f /data/adb/ksu/bin/sus_su ${MODDIR}/system/bin/su
-  cp -f /data/adb/ksu/bin/sus_su_drv_path ${MODDIR}/system/bin/sus_su_drv_path
-  echo 1 > ${MODDIR}/sus_su_mode
-  return
-}
-# uncomment it below to enable sus_su with mode 1 #
-#enable_sus_su_mode_1
-
 # SUS_SU 2#
 sus_su_2(){
   if ! ${SUSFS_BIN} sus_su 2; then


### PR DESCRIPTION
Hi,

Thank you for making this module to simplify the installation and settings of the susfs patch. For some reason, my device can only use the 1st mode otherwise the susfs will cause a kernel panic ([upstream issue](https://gitlab.com/simonpunk/susfs4ksu/-/issues/17https://gitlab.com/simonpunk/susfs4ksu/-/issues/17)).

So, I change some code to make mode 2 as default. When I flashed the module and restarted my device, I found that the root access was lost. It shows `su inaccessible or not found` when I open the WebUI and the adb shell. But everything works well when I am using the demo module in the  `susfs4ksu` repo

I compared this module and the demo one. I found the code about running the mode 1 should be placed in `post-fs-data.sh`. I moved the code and it works flawlessly now.

I hope you can review and accept this change. Thanks!