### PR TITLE
fix: add_try_umount param

### DIFF
--- a/post-mount.sh
+++ b/post-mount.sh
@@ -13,7 +13,7 @@ for i in $(grep -v "#" $PERSISTENT_DIR/sus_mount.txt); do
 	${SUSFS_BIN} add_sus_mount $i && echo "[sus_mount]: susfs4ksu/post-mount $i" >> $logfile1
 done
 for i in $(grep -v "#" $PERSISTENT_DIR/try_umount.txt); do
-	${SUSFS_BIN} add_try_umount $i && echo "[try_umount]: susfs4ksu/post-mount $i" >> $logfile1
+	${SUSFS_BIN} add_try_umount $i 1 && echo "[try_umount]: susfs4ksu/post-mount $i" >> $logfile1
 done
 
 # EOF


### PR DESCRIPTION
Hi,

I found that the custom path in `try_umount.txt` is not working. I checked the `add_try_umount` subcommand and I think we may need to put the `<mode>` parameter at the end.

```
add_try_umount </path/of/file_or_directory> <mode>
         |--> Added path will be umounted from KSU for all UIDs that are NOT su allowed, and profile template configured with umount
         |--> <mode>: 0 -> umount with no flags, 1 -> umount with MNT_DETACH
         |--> NOTE: susfs umount takes precedence of ksu umount
```

I hope you can review and accept this change. Thanks!