### PR TITLE
cmdline hw device name spoof

### DIFF
--- a/boot-completed.sh
+++ b/boot-completed.sh
@@ -66,6 +66,7 @@ fi
 [ $spoof_cmdline = 1 ] && {
 	echo "susfs4ksu/boot-completed: [spoof_cmdline]" >> $logfile1
 	sed 's|androidboot.verifiedbootstate=orange|androidboot.verifiedbootstate=green|g' /proc/cmdline > $mntfolder/cmdline
+        sed -i "s/androidboot.hwname=[^ ]*/androidboot.hwname=$(getprop ro.product.name)/; s/androidboot.product.hardware.sku=[^ ]*/androidboot.product.hardware.sku=$(getprop ro.product.name)/" $mntfolder/cmdline
 	if ! ${SUSFS_BIN} set_proc_cmdline $mntfolder/cmdline; then
 		${SUSFS_BIN} set_cmdline_or_bootconfig $mntfolder/cmdline
 	fi


### PR DESCRIPTION
Using getprop ro.product.name in order to spoof/replace values of androidboot.hwname and androidboot.product.hardware.sku