### PR TITLE
更新 service.sh

### DIFF
--- a/service.sh
+++ b/service.sh
@@ -178,5 +178,5 @@ rm ${tmpfolder}/susfs_stats1.txt
 echo sus_path=$(grep -ci 'sus_path' $logfile1 ) >> ${tmpfolder}/susfs_stats1.txt
 echo sus_mount=$(grep -ci 'sus_mount' $logfile1 ) >> ${tmpfolder}/susfs_stats1.txt
 echo try_umount=$(grep -ci 'try_umount' $logfile1 ) >> ${tmpfolder}/susfs_stats1.txt
-
+rm -rf $mntfolder
 # EOF


### PR DESCRIPTION
I apologize for the inconvenience this commit may have caused the developers. This issue appears to be related to the permission management of the "bin.mt.plus" app and is not caused by susfs. I would like to extend my sincere apologies to the developers—this was not a "malicious commit."








**Do not create folders in "/debug_ramdisk"! In "Android 15", the "/debug_ramdisk" directory can be listed with the "ls" command without requiring "root" permissions! (Other "Android" versions have not been tested.) This commit is solely intended to remove the "/debug_ramdisk/susfs4ksu" folder created by susfs during boot and does not include any fixes. If this commit causes any issues with susfs functionality, developers are advised to address and resolve them independently.**