### PR TITLE
feat: Enhance sus_su logic with final susfs activity check

### DIFF
--- a/service.sh
+++ b/service.sh
@@ -67,17 +67,24 @@ sus_su_2(){
 }
 
 [ $sus_su = -1 ] && {
-	if [ -n "$version" ] && [ "$SUSFS_DECIMAL" -gt 152 ] 2>/dev/null; then
-		# Check if sus_su is supported
-		if ${SUSFS_BIN} show enabled_features 2>/dev/null | grep -q "CONFIG_KSU_SUSFS_SUS_SU"; then
-  			sed -i "s/^sus_su=.*/sus_su=0/" ${PERSISTENT_DIR}/config.sh
-			${SUSFS_BIN} sus_su 0
-			sed -i "s/^sus_su_active=.*/sus_su_active=0/" ${PERSISTENT_DIR}/config.sh
-		fi
+	# Final check for susfs activity if sus_su is -1
+	if [ -f $tmpfolder/logs/susfs_active ] || dmesg | grep -q "susfs:"; then
+		sus_su=2
+		sed -i "s/^sus_su=.*/sus_su=2/" ${PERSISTENT_DIR}/config.sh
+		sed -i "s/^sus_su_active=.*/sus_su_active=2/" ${PERSISTENT_DIR}/config.sh
 	else
-		if ${SUSFS_BIN} sus_su 0; then
-  			sed -i "s/^sus_su=.*/sus_su=0/" ${PERSISTENT_DIR}/config.sh
-			sed -i "s/^sus_su_active=.*/sus_su_active=0/" ${PERSISTENT_DIR}/config.sh
+		if [ -n "$version" ] && [ "$SUSFS_DECIMAL" -gt 152 ] 2>/dev/null; then
+			# Check if sus_su is supported
+			if ${SUSFS_BIN} show enabled_features 2>/dev/null | grep -q "CONFIG_KSU_SUSFS_SUS_SU"; then
+				sed -i "s/^sus_su=.*/sus_su=0/" ${PERSISTENT_DIR}/config.sh
+				${SUSFS_BIN} sus_su 0
+				sed -i "s/^sus_su_active=.*/sus_su_active=0/" ${PERSISTENT_DIR}/config.sh
+			fi
+		else
+			if ${SUSFS_BIN} sus_su 0; then
+				sed -i "s/^sus_su=.*/sus_su=0/" ${PERSISTENT_DIR}/config.sh
+				sed -i "s/^sus_su_active=.*/sus_su_active=0/" ${PERSISTENT_DIR}/config.sh
+			fi
 		fi
 	fi
 }


### PR DESCRIPTION
### What's Changed?
- Added a final check for susfs activity when `sus_su` is set to `-1`.
- This check looks for `$tmpfolder/logs/susfs_active` or "susfs:" in `dmesg` output.
- If susfs is active, `sus_su` is set to `2` and config files are updated accordingly.

### Why?
- This change ensures that the `sus_su` status is accurately determined even if the initial checks fail.
- It improves reliability by adding a fallback mechanism to verify susfs activity.

### Testing:
- Tested on multiple devices with different susfs versions.
- Verified that the final check correctly updates `sus_su` when susfs is active.