### PR TITLE
Fix SuS status logic and revert service.sh to original version

### DIFF
--- a/boot-completed.sh
+++ b/boot-completed.sh
@@ -21,6 +21,9 @@ spoof_uname=0
 # update description
 if [ -f $tmpfolder/logs/susfs_active ] || dmesg | grep -q "susfs:"; then
 	description="description=status: ✅ SuS ඞ "
+	sus_su=2
+	sed -i "s/^sus_su=.*/sus_su=2/" ${PERSISTENT_DIR}/config.sh
+	sed -i "s/^sus_su_active=.*/sus_su_active=2/" ${PERSISTENT_DIR}/config.sh
 else
 	description="description=status: failed 💢 - Make sure you're on a SuSFS patched kernel! 😭"
 	rm -rf ${MODDIR}/webroot

--- a/service.sh
+++ b/service.sh
@@ -67,24 +67,17 @@ sus_su_2(){
 }
 
 [ $sus_su = -1 ] && {
-	# Final check for susfs activity if sus_su is -1
-	if [ -f $tmpfolder/logs/susfs_active ] || dmesg | grep -q "susfs:"; then
-		sus_su=2
-		sed -i "s/^sus_su=.*/sus_su=2/" ${PERSISTENT_DIR}/config.sh
-		sed -i "s/^sus_su_active=.*/sus_su_active=2/" ${PERSISTENT_DIR}/config.sh
+	if [ -n "$version" ] && [ "$SUSFS_DECIMAL" -gt 152 ] 2>/dev/null; then
+		# Check if sus_su is supported
+		if ${SUSFS_BIN} show enabled_features 2>/dev/null | grep -q "CONFIG_KSU_SUSFS_SUS_SU"; then
+  			sed -i "s/^sus_su=.*/sus_su=0/" ${PERSISTENT_DIR}/config.sh
+			${SUSFS_BIN} sus_su 0
+			sed -i "s/^sus_su_active=.*/sus_su_active=0/" ${PERSISTENT_DIR}/config.sh
+		fi
 	else
-		if [ -n "$version" ] && [ "$SUSFS_DECIMAL" -gt 152 ] 2>/dev/null; then
-			# Check if sus_su is supported
-			if ${SUSFS_BIN} show enabled_features 2>/dev/null | grep -q "CONFIG_KSU_SUSFS_SUS_SU"; then
-				sed -i "s/^sus_su=.*/sus_su=0/" ${PERSISTENT_DIR}/config.sh
-				${SUSFS_BIN} sus_su 0
-				sed -i "s/^sus_su_active=.*/sus_su_active=0/" ${PERSISTENT_DIR}/config.sh
-			fi
-		else
-			if ${SUSFS_BIN} sus_su 0; then
-				sed -i "s/^sus_su=.*/sus_su=0/" ${PERSISTENT_DIR}/config.sh
-				sed -i "s/^sus_su_active=.*/sus_su_active=0/" ${PERSISTENT_DIR}/config.sh
-			fi
+		if ${SUSFS_BIN} sus_su 0; then
+  			sed -i "s/^sus_su=.*/sus_su=0/" ${PERSISTENT_DIR}/config.sh
+			sed -i "s/^sus_su_active=.*/sus_su_active=0/" ${PERSISTENT_DIR}/config.sh
 		fi
 	fi
 }


### PR DESCRIPTION
This PR includes the following changes:

1. **Added `sus_su=2`** to the SuS status check logic to ensure proper status updates.
2. **Updated `sed -i` commands** to correctly modify `sus_su` and `sus_su_active` values in `config.sh`.
3. **Reverted `service.sh`** to its original version to maintain consistency with the base implementation.

These changes ensure the SuS status logic works as intended while keeping the `service.sh` file aligned with the original version.