### PR TITLE
scripts: remove /debug_ramdisk requirement

### DIFF
--- a/boot-completed.sh
+++ b/boot-completed.sh
@@ -4,7 +4,7 @@ SUSFS_BIN=/data/adb/ksu/bin/ksu_susfs
 . ${MODDIR}/utils.sh
 PERSISTENT_DIR=/data/adb/susfs4ksu
 tmpfolder=/data/adb/ksu/susfs4ksu
-mntfolder=/debug_ramdisk/susfs4ksu
+mntfolder=/dev/susfs4ksu
 logfile="$tmpfolder/logs/susfs.log"
 logfile1="$tmpfolder/logs/susfs1.log"
 version=$(${SUSFS_BIN} show version)

--- a/post-fs-data.sh
+++ b/post-fs-data.sh
@@ -4,7 +4,7 @@ SUSFS_BIN=/data/adb/ksu/bin/ksu_susfs
 . ${MODDIR}/utils.sh
 PERSISTENT_DIR=/data/adb/susfs4ksu
 tmpfolder=/data/adb/ksu/susfs4ksu
-mntfolder=/debug_ramdisk/susfs4ksu
+mntfolder=/dev/susfs4ksu
 mkdir -p $tmpfolder/logs
 mkdir -p $tmpfolder
 mkdir -p $mntfolder

--- a/post-mount.sh
+++ b/post-mount.sh
@@ -4,7 +4,7 @@ SUSFS_BIN=/data/adb/ksu/bin/ksu_susfs
 . ${MODDIR}/utils.sh
 PERSISTENT_DIR=/data/adb/susfs4ksu
 tmpfolder=/data/adb/ksu/susfs4ksu
-mntfolder=/debug_ramdisk/susfs4ksu
+mntfolder=/dev/susfs4ksu
 logfile="$tmpfolder/logs/susfs.log"
 logfile1="$tmpfolder/logs/susfs1.log"
 # to add mounts

--- a/service.sh
+++ b/service.sh
@@ -4,7 +4,7 @@ SUSFS_BIN=/data/adb/ksu/bin/ksu_susfs
 . ${MODDIR}/utils.sh
 PERSISTENT_DIR=/data/adb/susfs4ksu
 tmpfolder=/data/adb/ksu/susfs4ksu
-mntfolder=/debug_ramdisk/susfs4ksu
+mntfolder=/dev/susfs4ksu
 logfile1="$tmpfolder/logs/susfs1.log"
 logfile="$tmpfolder/logs/susfs.log"
 version=$(${SUSFS_BIN} show version)


### PR DESCRIPTION
theres no need nowadays for most modules to have this unless youre on magic mount. on magic mount this is needed for workdir.

but then if youre on .nomount, the tmpfs is useless so you can just turn the damn thing off.

most modules nowadays are now adapted to missing /debug_ramdisk tmpfs. figured out this modules should start moving to this direction too.

please review and test before merging.
another is that I am not planning to check webui side of things.