### PR TITLE
correct undefined $i variable in log output statements in service.sh, correct artifact upload pattern to exclude directories

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,10 +54,10 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: release-1.5.2+_${{ env.BUILD_ID }}
-          path: ${{ github.workspace }}
-          exclude: |
-            .git/**
-            .github/**
-            node_modules/**
-            src/**
-            tests/**
+          path: |
+            ${{ github.workspace }}/**/*
+            !${{ github.workspace }}/.git/**
+            !${{ github.workspace }}/.github/**
+            !${{ github.workspace }}/node_modules/**
+            !${{ github.workspace }}/src/**
+            !${{ github.workspace }}/tests/**

--- a/service.sh
+++ b/service.sh
@@ -138,8 +138,8 @@ fi
 [ $hide_loops = 1 ] && {
 	echo "susfs4ksu/service: [hide_loops]" >> $logfile1
 	for device in $(ls -Ld /proc/fs/jbd2/loop*8 | sed 's|/proc/fs/jbd2/||; s|-8||'); do
-		${SUSFS_BIN} add_sus_path /proc/fs/jbd2/${device}-8 && echo "[sus_path]: susfs4ksu/service $i" >> $logfile1
-		${SUSFS_BIN} add_sus_path /proc/fs/ext4/${device} && echo "[sus_path]: susfs4ksu/service $i" >> $logfile1
+		${SUSFS_BIN} add_sus_path /proc/fs/jbd2/${device}-8 && echo "[sus_path]: susfs4ksu/service /proc/fs/jbd2/${device}-8" >> $logfile1
+		${SUSFS_BIN} add_sus_path /proc/fs/ext4/${device} && echo "[sus_path]: susfs4ksu/service /proc/fs/ext4/${device}" >> $logfile1
 	done
 }
 
@@ -149,11 +149,11 @@ fi
 	sepolicy_cil=/vendor/etc/selinux/vendor_sepolicy.cil
 	grep -q lineage $sepolicy_cil && {
 		grep -v "lineage" $sepolicy_cil > $mntfolder/vendor_sepolicy.cil
-		${SUSFS_BIN} add_sus_kstat $sepolicy_cil && echo "[update_sus_kstat]: susfs4ksu/service $i" >> $logfile1
+		${SUSFS_BIN} add_sus_kstat $sepolicy_cil && echo "[update_sus_kstat]: susfs4ksu/service $sepolicy_cil" >> $logfile1
 		susfs_clone_perm $mntfolder/vendor_sepolicy.cil $sepolicy_cil
 		mount --bind $mntfolder/vendor_sepolicy.cil $sepolicy_cil
-		${SUSFS_BIN} update_sus_kstat $sepolicy_cil && echo "[update_sus_kstat]: susfs4ksu/service $i" >> $logfile1
-		${SUSFS_BIN} add_sus_mount $sepolicy_cil && echo "[sus_mount]: susfs4ksu/service $i" >> $logfile1
+		${SUSFS_BIN} update_sus_kstat $sepolicy_cil && echo "[update_sus_kstat]: susfs4ksu/service $sepolicy_cil" >> $logfile1
+		${SUSFS_BIN} add_sus_mount $sepolicy_cil && echo "[sus_mount]: susfs4ksu/service $sepolicy_cil" >> $logfile1
 	}
 }
 
@@ -163,11 +163,11 @@ fi
 	compatibility_matrix=/system/etc/vintf/compatibility_matrix.device.xml
 	grep -q lineage $compatibility_matrix && {
 		grep -v "lineage" $compatibility_matrix > $mntfolder/compatibility_matrix.device.xml
-		${SUSFS_BIN} add_sus_kstat $compatibility_matrix && echo "[update_sus_kstat]: susfs4ksu/service $i" >> $logfile1
+		${SUSFS_BIN} add_sus_kstat $compatibility_matrix && echo "[update_sus_kstat]: susfs4ksu/service $compatibility_matrix" >> $logfile1
 		susfs_clone_perm $mntfolder/compatibility_matrix.device.xml $compatibility_matrix
 		mount --bind $mntfolder/compatibility_matrix.device.xml $compatibility_matrix
-		${SUSFS_BIN} update_sus_kstat $compatibility_matrix && echo "[update_sus_kstat]: susfs4ksu/service $i" >> $logfile1
-		${SUSFS_BIN} add_sus_mount $compatibility_matrix && echo "[sus_mount]: susfs4ksu/service $i" >> $logfile1
+		${SUSFS_BIN} update_sus_kstat $compatibility_matrix && echo "[update_sus_kstat]: susfs4ksu/service $compatibility_matrix" >> $logfile1
+		${SUSFS_BIN} add_sus_mount $compatibility_matrix && echo "[sus_mount]: susfs4ksu/service $compatibility_matrix" >> $logfile1
 	}
 }
 


### PR DESCRIPTION
- Replace invalid 'exclude' parameter with proper path pattern negation (!pattern) 
in actions/upload-artifact@v4 configuration. This ensures .git, .github, 
node_modules, src, and tests directories are properly excluded from the release
artifact.

- Replace undefined $i variable with proper variable names in logging statements
throughout the service.sh.