### PR TITLE
Prevent the detection of the ro.boot.vbmeta.size value

### DIFF
--- a/customize.sh
+++ b/customize.sh
@@ -120,6 +120,25 @@ for i in $files ; do
     fi
     rm $MODPATH/$i
 done
+# Get the real ro.boot.vbmeta.size value
+# If unavailable, generate a random 4K-aligned value with probability distribution (10%-50%-25%-15%)
+vbmeta_size=$(blockdev --getsize64 /dev/block/by-name/vbmeta_a 2>/dev/null)
+[ -z "$vbmeta_size" ] || [ "$vbmeta_size" -eq 0 ] && \
+  vbmeta_size=$(blockdev --getsize64 /dev/block/by-name/vbmeta_b 2>/dev/null)
+[ -z "$vbmeta_size" ] || [ "$vbmeta_size" -eq 0 ] && {
+  roll=$(( RANDOM % 100 + 1 ))
+  [ $roll -le 5 ] && vbmeta_size=$(( 262144 + (RANDOM % 769 + 1)*256 ))        # 256KB~1MB
+  [ $roll -gt 5 ] && [ $roll -le 55 ] && vbmeta_size=$(( 1048576 + (RANDOM % 769 + 1)*4096 ))   # 1MB~4MB
+  [ $roll -gt 55 ] && [ $roll -le 80 ] && vbmeta_size=$(( 4194304 + (RANDOM % 1025 + 1)*4096 ))  # 4MB~8MB
+  [ $roll -gt 80 ] && vbmeta_size=$(( 8388608 + (RANDOM % 1025 + 1)*4096 ))    # 8MB~12MB
+}
+
+# Precisely overwrite vbmeta_size in config
+if grep -q "^vbmeta_size=" /data/adb/susfs4ksu/config.sh; then
+    sed -i "s/^vbmeta_size=.*/vbmeta_size=$vbmeta_size/" /data/adb/susfs4ksu/config.sh
+else
+    echo "vbmeta_size=$vbmeta_size" >> /data/adb/susfs4ksu/config.sh
+fi
 
 rm -rf ${MODPATH}/tools
 rm ${MODPATH}/customize.sh ${MODPATH}/README.md

--- a/service.sh
+++ b/service.sh
@@ -93,12 +93,12 @@ resetprop -w sys.boot_completed 0
 check_vbmeta_prop "ro.boot.vbmeta.invalidate_on_error" yes
 check_vbmeta_prop "ro.boot.vbmeta.avb_version" "1.2"
 check_vbmeta_prop "ro.boot.vbmeta.hash_alg" "sha256"
+check_vbmeta_prop "ro.boot.vbmeta.device_state" "locked"
 
 # Extract vbmeta_size value from config file, fallback to default 65536 (64KB, 4K-aligned) if failed
 vbmeta_size=$(grep "^vbmeta_size=" /data/adb/susfs4ksu/config.sh | cut -d'=' -f2 || echo "65536")
 check_vbmeta_prop "ro.boot.vbmeta.size" "$vbmeta_size"
 
-resetprop "ro.boot.vbmeta.device_state" "locked"
 resetprop "ro.boot.verifiedbootstate" "green"
 resetprop "ro.boot.flash.locked" "1"
 resetprop "ro.boot.veritymode" "enforcing"

--- a/service.sh
+++ b/service.sh
@@ -93,7 +93,10 @@ resetprop -w sys.boot_completed 0
 check_vbmeta_prop "ro.boot.vbmeta.invalidate_on_error" yes
 check_vbmeta_prop "ro.boot.vbmeta.avb_version" "1.2"
 check_vbmeta_prop "ro.boot.vbmeta.hash_alg" "sha256"
-check_vbmeta_prop "ro.boot.vbmeta.size" "$(( RANDOM % (7000 - 1000 + 1) + 3000 ))"
+
+# Extract vbmeta_size value from config file, fallback to default 65536 (64KB, 4K-aligned) if failed
+vbmeta_size=$(grep "^vbmeta_size=" /data/adb/susfs4ksu/config.sh | cut -d'=' -f2 || echo "65536")
+check_vbmeta_prop "ro.boot.vbmeta.size" "$vbmeta_size"
 
 resetprop "ro.boot.vbmeta.device_state" "locked"
 resetprop "ro.boot.verifiedbootstate" "green"

--- a/service.sh
+++ b/service.sh
@@ -96,7 +96,8 @@ check_vbmeta_prop "ro.boot.vbmeta.hash_alg" "sha256"
 check_vbmeta_prop "ro.boot.vbmeta.device_state" "locked"
 
 # Extract vbmeta_size value from config file, fallback to default 65536 (64KB, 4K-aligned) if failed
-vbmeta_size=$(grep "^vbmeta_size=" /data/adb/susfs4ksu/config.sh | cut -d'=' -f2 || echo "65536")
+vbmeta_size=$(sed -n 's/^vbmeta_size=//p' /data/adb/susfs4ksu/config.sh 2>/dev/null)
+vbmeta_size=${vbmeta_size:-65536}
 check_vbmeta_prop "ro.boot.vbmeta.size" "$vbmeta_size"
 
 resetprop "ro.boot.verifiedbootstate" "green"


### PR DESCRIPTION
For `ro.boot.vbmeta.size`, use a static value to prevent detection. Otherwise, if a random value is used each time, it will change with every reboot. If any application records and associates this value with device information, then performs two comparisons, there would be a risk of exposure. 

Additionally, if using random values, they must comply with AVB's official documentation: "Partition size must be multiples of the block size used by dm-verity (typically 4096 bytes)."