### PR TITLE
Revert to previous version's random value calculation method, only retain writing to config for service retrieval

### DIFF
--- a/customize.sh
+++ b/customize.sh
@@ -120,18 +120,10 @@ for i in $files ; do
     fi
     rm $MODPATH/$i
 done
-# Get the real ro.boot.vbmeta.size value
-# If unavailable, generate a random 4K-aligned value with probability distribution (10%-50%-25%-15%)
-vbmeta_size=$(blockdev --getsize64 /dev/block/by-name/vbmeta_a 2>/dev/null)
-[ -z "$vbmeta_size" ] || [ "$vbmeta_size" -eq 0 ] && \
-  vbmeta_size=$(blockdev --getsize64 /dev/block/by-name/vbmeta_b 2>/dev/null)
-[ -z "$vbmeta_size" ] || [ "$vbmeta_size" -eq 0 ] && {
-  roll=$(( RANDOM % 100 + 1 ))
-  [ $roll -le 5 ] && vbmeta_size=$(( 262144 + (RANDOM % 769 + 1)*256 ))        # 256KB~1MB
-  [ $roll -gt 5 ] && [ $roll -le 55 ] && vbmeta_size=$(( 1048576 + (RANDOM % 769 + 1)*4096 ))   # 1MB~4MB
-  [ $roll -gt 55 ] && [ $roll -le 80 ] && vbmeta_size=$(( 4194304 + (RANDOM % 1025 + 1)*4096 ))  # 4MB~8MB
-  [ $roll -gt 80 ] && vbmeta_size=$(( 8388608 + (RANDOM % 1025 + 1)*4096 ))    # 8MB~12MB
-}
+
+# Random ro.boot.vbmeta.size value
+# vbmeta_size=$(( 5504 + (RANDOM % 14 + 1)*1024 ))  # 5504~16384, 1KB对齐
+vbmeta_size="$(( RANDOM % (7000 - 1000 + 1) + 3000 ))"
 
 # Precisely overwrite vbmeta_size in config
 if grep -q "^vbmeta_size=" /data/adb/susfs4ksu/config.sh; then

--- a/service.sh
+++ b/service.sh
@@ -95,7 +95,7 @@ check_reset_prop "ro.boot.vbmeta.avb_version" "1.2"
 check_reset_prop "ro.boot.vbmeta.hash_alg" "sha256"
 check_reset_prop "ro.boot.vbmeta.device_state" "locked"
 
-# Extract vbmeta_size value from config file, fallback to default 65536 (64KB, 4K-aligned) if failed
+# Extract vbmeta_size from config file, fallback to 5248 if missing.
 vbmeta_size=$(sed -n 's/^vbmeta_size=//p' /data/adb/susfs4ksu/config.sh 2>/dev/null)
 vbmeta_size=${vbmeta_size:-5248}
 check_reset_prop "ro.boot.vbmeta.size" "$vbmeta_size"

--- a/service.sh
+++ b/service.sh
@@ -97,7 +97,7 @@ check_reset_prop "ro.boot.vbmeta.device_state" "locked"
 
 # Extract vbmeta_size value from config file, fallback to default 65536 (64KB, 4K-aligned) if failed
 vbmeta_size=$(sed -n 's/^vbmeta_size=//p' /data/adb/susfs4ksu/config.sh 2>/dev/null)
-vbmeta_size=${vbmeta_size:-65536}
+vbmeta_size=${vbmeta_size:-5248}
 check_reset_prop "ro.boot.vbmeta.size" "$vbmeta_size"
 
 check_reset_prop "ro.boot.verifiedbootstate" "green"


### PR DESCRIPTION
Based on my device relocking tests:
The value from  getprop ro.boot.vbmeta.size  was "7808" (logical size of signed data, manufacturer-specific alignment, non-standard AVB specification).
After unlocking,  getprop ro.boot.vbmeta.size  returns: 131072 (physical partition size).
Clearly we should use the pre-unlock value as reference.
 
Some manufacturers use proprietary alignment methods instead of the standard AVB specification's 64B/1KB/4KB alignment. Random values cannot reliably cover all manufacturers' devices.
 
The process to accurately obtain pre-unlock values is somewhat complex and error-prone. We recommend either relocking and reflashing the firmware or analyzing the original factory firmware to get this value.