### PR TITLE
Change the  vbmeta.size  value

### DIFF
--- a/customize.sh
+++ b/customize.sh
@@ -121,6 +121,16 @@ for i in $files ; do
     rm $MODPATH/$i
 done
 
+# Random ro.boot.vbmeta.size value
+vbmeta_size=$(( 5504 + (RANDOM % 14 + 1)*1024 ))  # 5504~16384
+
+# Data persistence
+if grep -q "^vbmeta_size=" /data/adb/susfs4ksu/config.sh; then
+    sed -i "s/^vbmeta_size=.*/vbmeta_size=$vbmeta_size/" /data/adb/susfs4ksu/config.sh
+else
+    echo "vbmeta_size=$vbmeta_size" >> /data/adb/susfs4ksu/config.sh
+fi
+
 rm -rf ${MODPATH}/tools
 rm ${MODPATH}/customize.sh ${MODPATH}/README.md
 

--- a/service.sh
+++ b/service.sh
@@ -100,7 +100,7 @@ check_missing_prop "ro.boot.vbmeta.hash_alg" "sha256"
 # Extract vbmeta_size from config file, fallback to 8192 if missing.
 vbmeta_size=$(sed -n 's/^vbmeta_size=//p' /data/adb/susfs4ksu/config.sh 2>/dev/null)
 vbmeta_size=${vbmeta_size:-8192}
-check_reset_prop "ro.boot.vbmeta.size" "$vbmeta_size"
+check_missing_prop "ro.boot.vbmeta.size" "$vbmeta_size"
 
 check_missing_prop "ro.boot.vbmeta.device_state" "locked"
 check_missing_prop "ro.boot.verifiedbootstate" "green"

--- a/service.sh
+++ b/service.sh
@@ -96,7 +96,11 @@ resetprop -w sys.boot_completed 0
 check_missing_prop "ro.boot.vbmeta.invalidate_on_error" yes
 check_missing_prop "ro.boot.vbmeta.avb_version" "1.2"
 check_missing_prop "ro.boot.vbmeta.hash_alg" "sha256"
-check_missing_prop "ro.boot.vbmeta.size" "$(( RANDOM % (7000 - 1000 + 1) + 3000 ))"
+
+# Extract vbmeta_size from config file, fallback to 8192 if missing.
+vbmeta_size=$(sed -n 's/^vbmeta_size=//p' /data/adb/susfs4ksu/config.sh 2>/dev/null)
+vbmeta_size=${vbmeta_size:-8192}
+check_reset_prop "ro.boot.vbmeta.size" "$vbmeta_size"
 
 check_missing_prop "ro.boot.vbmeta.device_state" "locked"
 check_missing_prop "ro.boot.verifiedbootstate" "green"


### PR DESCRIPTION
Preserve the user's original value instead of overwriting it.
It is recommended to implement persistent storage - frequent changes may cause apps to flag the device as abnormal.