### PR TITLE
resetprop ro.kernel.qemu only if existing and set to something else then nothing

### DIFF
--- a/service.sh
+++ b/service.sh
@@ -136,7 +136,7 @@ contains_reset_prop "ro.boot.bootmode" "recovery" "unknown"
 contains_reset_prop "vendor.boot.bootmode" "recovery" "unknown"
 
 # ro.kernel.qemu = 0 will trigger Hunter(root checker app) for possible cloud phone; resetprop --delete will trigger "found hole in prop area: u:object_r:exported_default_prop:s0"
-check_reset_prop "ro.kernel.qemu" ""
+check_reset_prop "ro.kernel.qemu" " "
 
 # fake encryption status
 check_reset_prop "ro.crypto.state" "encrypted"

--- a/service.sh
+++ b/service.sh
@@ -135,8 +135,8 @@ contains_reset_prop "ro.bootmode" "recovery" "unknown"
 contains_reset_prop "ro.boot.bootmode" "recovery" "unknown"
 contains_reset_prop "vendor.boot.bootmode" "recovery" "unknown"
 
-# ro.kernel.qemu = 0 will trigger Hunter(root checker app) for possible cloud phone; resetprop --delete will trigger "found hole in prop area: u:object_r:exported_default_prop:s0"
-check_reset_prop "ro.kernel.qemu" " "
+# Hide cloudphone detection
+[ -n "$(resetprop ro.kernel.qemu)" ] && resetprop ro.kernel.qemu ""
 
 # fake encryption status
 check_reset_prop "ro.crypto.state" "encrypted"

--- a/service.sh
+++ b/service.sh
@@ -135,6 +135,9 @@ contains_reset_prop "ro.bootmode" "recovery" "unknown"
 contains_reset_prop "ro.boot.bootmode" "recovery" "unknown"
 contains_reset_prop "vendor.boot.bootmode" "recovery" "unknown"
 
+# ro.kernel.qemu = 0 will trigger Hunter(root checker app) for possible cloud phone; resetprop --delete will trigger "found hole in prop area: u:object_r:exported_default_prop:s0"
+check_reset_prop "ro.kernel.qemu" ""
+
 # fake encryption status
 check_reset_prop "ro.crypto.state" "encrypted"
 


### PR DESCRIPTION
ro.kernel.qemu gets flaged by Hunter(root detector app) as possible cloud phone.
delete prop if exists will open vurnability to other detections like manipulated readonly props.
so it has to be set to "" to avoid detections.
check_reset_prop doesnt work with empty string as $VALUE