### PR TITLE
Since vold app data isolation prop has reset, why not reset another?

### DIFF
--- a/service.sh
+++ b/service.sh
@@ -122,6 +122,7 @@ check_reset_prop "sys.oem_unlock_allowed" "0"
 
 # HMA/L specific
 check_reset_prop "persist.sys.vold_app_data_isolation_enabled" "0"
+check_reset_prop "persist.zygote.app_data_isolation" "0"
 
 # MIUI specific
 check_reset_prop "ro.secureboot.lockstate" "locked"


### PR DESCRIPTION
Prop "persist.zygote.app_data_isolation" is related to /data/data isolation. By checking this, HMA may be leaked.