### PR TITLE
scripts: service: hide adb prop by removing sys.usb.adb.disabled

### DIFF
--- a/service.sh
+++ b/service.sh
@@ -120,6 +120,9 @@ check_reset_prop "ro.vendor.boot.warranty_bit" "0"
 check_reset_prop "ro.vendor.warranty_bit" "0"
 check_reset_prop "sys.oem_unlock_allowed" "0"
 
+#Hide adb debugging traces
+resetprop "sys.usb.adb.disabled" " "
+
 # HMA/L specific
 check_reset_prop "persist.sys.vold_app_data_isolation_enabled" "0"
 


### PR DESCRIPTION
Hide adb debugging traces