### PR TITLE
Hide "lineage" from /vendor/etc/selinux/vendor_file_contexts

### DIFF
--- a/service.sh
+++ b/service.sh
@@ -172,10 +172,10 @@ fi
 		grep -q lineage $sepolicy_cil && {
 			cil_name=`basename "$sepolicy_cil"`
 			grep -v "lineage" $sepolicy_cil > $mntfolder/$cil_name
-			${SUSFS_BIN} add_sus_kstat $sepolicy_cil && echo "[update_sus_kstat]: susfs4ksu/service $sepolicy_cil" >> $logfile1
+			#${SUSFS_BIN} add_sus_kstat $sepolicy_cil && echo "[update_sus_kstat]: susfs4ksu/service $sepolicy_cil" >> $logfile1
 			susfs_clone_perm $mntfolder/$cil_name $sepolicy_cil
 			mount --bind $mntfolder/$cil_name $sepolicy_cil
-			${SUSFS_BIN} update_sus_kstat $sepolicy_cil && echo "[update_sus_kstat]: susfs4ksu/service $sepolicy_cil" >> $logfile1
+			#${SUSFS_BIN} update_sus_kstat $sepolicy_cil && echo "[update_sus_kstat]: susfs4ksu/service $sepolicy_cil" >> $logfile1
 			${SUSFS_BIN} add_sus_mount $sepolicy_cil && echo "[sus_mount]: susfs4ksu/service $sepolicy_cil" >> $logfile1
 		}
 	done
@@ -187,10 +187,10 @@ fi
 	compatibility_matrix=/system/etc/vintf/compatibility_matrix.device.xml
 	grep -q lineage $compatibility_matrix && {
 		grep -v "lineage" $compatibility_matrix > $mntfolder/compatibility_matrix.device.xml
-		${SUSFS_BIN} add_sus_kstat $compatibility_matrix && echo "[update_sus_kstat]: susfs4ksu/service $compatibility_matrix" >> $logfile1
+		#${SUSFS_BIN} add_sus_kstat $compatibility_matrix && echo "[update_sus_kstat]: susfs4ksu/service $compatibility_matrix" >> $logfile1
 		susfs_clone_perm $mntfolder/compatibility_matrix.device.xml $compatibility_matrix
 		mount --bind $mntfolder/compatibility_matrix.device.xml $compatibility_matrix
-		${SUSFS_BIN} update_sus_kstat $compatibility_matrix && echo "[update_sus_kstat]: susfs4ksu/service $compatibility_matrix" >> $logfile1
+		#${SUSFS_BIN} update_sus_kstat $compatibility_matrix && echo "[update_sus_kstat]: susfs4ksu/service $compatibility_matrix" >> $logfile1
 		${SUSFS_BIN} add_sus_mount $compatibility_matrix && echo "[sus_mount]: susfs4ksu/service $compatibility_matrix" >> $logfile1
 	}
 }

--- a/service.sh
+++ b/service.sh
@@ -166,15 +166,16 @@ fi
 	echo "susfs4ksu/service: [hide_vendor_sepolicy]" >> $logfile1
 	for sepolicy_cil in \
 		/vendor/etc/selinux/vendor_sepolicy.cil \
+		/vendor/etc/selinux/vendor_file_contexts \
 		/system_ext/etc/selinux/system_ext_sepolicy.cil
 	do
 		grep -q lineage $sepolicy_cil && {
 			cil_name=`basename "$sepolicy_cil"`
 			grep -v "lineage" $sepolicy_cil > $mntfolder/$cil_name
-			#${SUSFS_BIN} add_sus_kstat $sepolicy_cil && echo "[update_sus_kstat]: susfs4ksu/service $sepolicy_cil" >> $logfile1
+			${SUSFS_BIN} add_sus_kstat $sepolicy_cil && echo "[update_sus_kstat]: susfs4ksu/service $sepolicy_cil" >> $logfile1
 			susfs_clone_perm $mntfolder/$cil_name $sepolicy_cil
 			mount --bind $mntfolder/$cil_name $sepolicy_cil
-			#${SUSFS_BIN} update_sus_kstat $sepolicy_cil && echo "[update_sus_kstat]: susfs4ksu/service $sepolicy_cil" >> $logfile1
+			${SUSFS_BIN} update_sus_kstat $sepolicy_cil && echo "[update_sus_kstat]: susfs4ksu/service $sepolicy_cil" >> $logfile1
 			${SUSFS_BIN} add_sus_mount $sepolicy_cil && echo "[sus_mount]: susfs4ksu/service $sepolicy_cil" >> $logfile1
 		}
 	done
@@ -186,10 +187,10 @@ fi
 	compatibility_matrix=/system/etc/vintf/compatibility_matrix.device.xml
 	grep -q lineage $compatibility_matrix && {
 		grep -v "lineage" $compatibility_matrix > $mntfolder/compatibility_matrix.device.xml
-		#${SUSFS_BIN} add_sus_kstat $compatibility_matrix && echo "[update_sus_kstat]: susfs4ksu/service $compatibility_matrix" >> $logfile1
+		${SUSFS_BIN} add_sus_kstat $compatibility_matrix && echo "[update_sus_kstat]: susfs4ksu/service $compatibility_matrix" >> $logfile1
 		susfs_clone_perm $mntfolder/compatibility_matrix.device.xml $compatibility_matrix
 		mount --bind $mntfolder/compatibility_matrix.device.xml $compatibility_matrix
-		#${SUSFS_BIN} update_sus_kstat $compatibility_matrix && echo "[update_sus_kstat]: susfs4ksu/service $compatibility_matrix" >> $logfile1
+		${SUSFS_BIN} update_sus_kstat $compatibility_matrix && echo "[update_sus_kstat]: susfs4ksu/service $compatibility_matrix" >> $logfile1
 		${SUSFS_BIN} add_sus_mount $compatibility_matrix && echo "[sus_mount]: susfs4ksu/service $compatibility_matrix" >> $logfile1
 	}
 }


### PR DESCRIPTION
Also, for both hide_vendor_sepolicy & hide_compat_matrix: These are not hidden from (e.g. ND, Disclosure) unless comments removed from the lines:
${SUSFS_BIN} add_sus_kstat
${SUSFS_BIN} update_sus_kstat
(I don't get EACCESS error, but if this varies then please ignore that part)

Note that fake service list does not work regardless of kstat so untouched