### PR TITLE
fix GKI bootconfig spoof formatting

### DIFF
--- a/boot-completed.sh
+++ b/boot-completed.sh
@@ -242,15 +242,20 @@ fi
 	
 	# Spoof cmdline and bootconfig
 	if grep -q "androidboot.verifiedbootstate" /proc/cmdline; then
-        sed 's|androidboot.verifiedbootstate=orange|androidboot.verifiedbootstate=green|g' /proc/cmdline > $mntfolder/cmdline
-    else
-		sed 's|androidboot.verifiedbootstate=orange|androidboot.verifiedbootstate=green|g' /proc/bootconfig > $mntfolder/bootconfig    
+		sed 's|androidboot\.verifiedbootstate=orange|androidboot.verifiedbootstate=green|g' /proc/cmdline > $mntfolder/cmdline
+	else
+		# GKI bootconfig uses `key = "value"`, unlike the compact cmdline format.
+		sed 's|androidboot\.verifiedbootstate[[:space:]]*=[[:space:]]*"orange"|androidboot.verifiedbootstate = "green"|g' /proc/bootconfig > $mntfolder/bootconfig
 	fi	
 		
 	if grep -q "androidboot.hwname\|androidboot.product.hardware.sku" /proc/cmdline; then
-		sed -i "s/androidboot.hwname=[^ ]*/androidboot.hwname=$(getprop ro.product.name)/; s/androidboot.product.hardware.sku=[^ ]*/androidboot.product.hardware.sku=$(getprop ro.product.name)/" $mntfolder/cmdline
+		sed -i "s/androidboot\.hwname=[^ ]*/androidboot.hwname=$(getprop ro.product.name)/; s/androidboot\.product\.hardware\.sku=[^ ]*/androidboot.product.hardware.sku=$(getprop ro.product.name)/" $mntfolder/cmdline
 	else
-		sed -i "s/androidboot.hwname=[^ ]*/androidboot.hwname=$(getprop ro.product.name)/; s/androidboot.product.hardware.sku=[^ ]*/androidboot.product.hardware.sku=$(getprop ro.product.name)/" $mntfolder/bootconfig
+		product_name=$(getprop ro.product.name)
+		sed -i \
+			-e "s|androidboot\.hwname[[:space:]]*=[[:space:]]*\"[^\"]*\"|androidboot.hwname = \"$product_name\"|g" \
+			-e "s|androidboot\.product\.hardware\.sku[[:space:]]*=[[:space:]]*\"[^\"]*\"|androidboot.product.hardware.sku = \"$product_name\"|g" \
+			$mntfolder/bootconfig
 	fi
 	
 	#check for susfs version and use the appropriate method


### PR DESCRIPTION
## What changed

- handle GKI `/proc/bootconfig` formatting (`key = "value"`) when spoofing `androidboot.verifiedbootstate`
- handle the same quoted/spaced formatting for `androidboot.hwname` and `androidboot.product.hardware.sku`

## Root cause

The existing substitutions only match compact kernel cmdline values such as `androidboot.verifiedbootstate=orange`. GKI exposes the same value through `/proc/bootconfig` as `androidboot.verifiedbootstate = "orange"`, so the R27 userspace module passed the original orange state back to the SUSFS kernel hook unchanged.

Reproduced on Pixel 8 Pro (`husky`), Android 17, GKI 6.1, SUSFS v2.2.0. A direct `set_cmdline_or_bootconfig` call with the corrected buffer changes the live output to `green`, confirming the kernel hook itself works.

## Validation

- `sh -n boot-completed.sh`
- `shellcheck -S error boot-completed.sh`
- installed the patched R27 module on the Pixel and completed a full reboot
- `adb shell su -c "grep androidboot.verifiedbootstate /proc/bootconfig"` returns `androidboot.verifiedbootstate = "green"`
- existing SUSFS configuration remains preserved
